### PR TITLE
use XORBytes utility in crypto/subtle

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: '1.20'
 
     - name: Build
       run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,7 @@
 module github.com/kasperdi/SPHINCSPLUS-golang
 
-go 1.15
+go 1.20
 
-require (
-	golang.org/x/crypto v0.0.0-20220518034528-6f7dac969898
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
-)
+require golang.org/x/crypto v0.0.0-20220518034528-6f7dac969898
+
+require golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,4 @@
 golang.org/x/crypto v0.0.0-20220518034528-6f7dac969898 h1:SLP7Q4Di66FONjDJbCYrCRrh97focO6sLogHO7/g8F0=
 golang.org/x/crypto v0.0.0-20220518034528-6f7dac969898/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/tweakable/sha256Tweak.go
+++ b/tweakable/sha256Tweak.go
@@ -3,6 +3,7 @@ package tweakable
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/subtle"
 
 	"github.com/kasperdi/SPHINCSPLUS-golang/address"
 	"github.com/kasperdi/SPHINCSPLUS-golang/util"
@@ -51,7 +52,8 @@ func (h *Sha256Tweak) F(PKseed []byte, adrs *address.ADRS, tmp []byte) []byte {
 
 	if h.Variant == Robust {
 		bitmask := mgf1sha256(append(PKseed, compressedADRS...), len(tmp))
-		M1 = util.XorBytes(tmp, bitmask)
+		M1 = make([]byte, len(tmp))
+		_ = subtle.XORBytes(M1, tmp, bitmask)
 	} else if h.Variant == Simple {
 		M1 = tmp
 	}

--- a/tweakable/shake256Tweak.go
+++ b/tweakable/shake256Tweak.go
@@ -1,8 +1,9 @@
 package tweakable
 
 import (
+	"crypto/subtle"
+
 	"github.com/kasperdi/SPHINCSPLUS-golang/address"
-	"github.com/kasperdi/SPHINCSPLUS-golang/util"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -51,7 +52,8 @@ func (h *Shake256Tweak) F(PKseed []byte, adrs *address.ADRS, tmp []byte) []byte 
 
 	if h.Variant == Robust {
 		bitmask := generateBitmask(PKseed, adrs, 8*len(tmp))
-		M1 = util.XorBytes(tmp, bitmask)
+		M1 = make([]byte, len(tmp))
+		_ = subtle.XORBytes(M1, tmp, bitmask)
 	} else if h.Variant == Simple {
 		M1 = tmp
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -31,15 +31,6 @@ func BytesToUint32(in []byte) uint32 {
 	return res
 }
 
-// Returns a XOR b, where a and b has to have same length
-func XorBytes(a []byte, b []byte) []byte {
-	res := make([]byte, len(a))
-	for i, elem := range a {
-		res[i] = elem ^ b[i]
-	}
-	return res
-}
-
 func Base_w(X []byte, w int, out_len int) []int {
 	in := 0
 	out := 0


### PR DESCRIPTION
Use the [XOR utility function in crypto/subtle](https://pkg.go.dev/crypto/subtle#XORBytes), which has architecture specific assembly implementations.  This change also requires updating the minimum go version to `1.20` as that's when the `subtle.XORBytes` utility was added.

Benchmark before:
```
goos: darwin
goarch: arm64
pkg: github.com/kasperdi/SPHINCSPLUS-golang/sphincs
BenchmarkSphincsPlus/Keygen_SHA256256f-Robust-10                     216           5552954 ns/op
BenchmarkSphincsPlus/Sign_SHA256256f-Robust-10                         9         111270435 ns/op
BenchmarkSphincsPlus/Verify_SHA256256f-Robust-10                     370           3196542 ns/op
BenchmarkSphincsPlus/Keygen_SHA256256s-Robust-10                      13          88897792 ns/op
BenchmarkSphincsPlus/Sign_SHA256256s-Robust-10                         1        1059779208 ns/op
BenchmarkSphincsPlus/Verify_SHA256256s-Robust-10                     664           1632545 ns/op
BenchmarkSphincsPlus/Keygen_SHA256256f-Simple-10                     441           2700432 ns/op
BenchmarkSphincsPlus/Sign_SHA256256f-Simple-10                        20          55976081 ns/op
BenchmarkSphincsPlus/Verify_SHA256256f-Simple-10                     787           1500519 ns/op
BenchmarkSphincsPlus/Keygen_SHA256256s-Simple-10                      26          43147657 ns/op
BenchmarkSphincsPlus/Sign_SHA256256s-Simple-10                         2         542432083 ns/op
BenchmarkSphincsPlus/Verify_SHA256256s-Simple-10                    1587            783734 ns/op
BenchmarkSphincsPlus/Keygen_SHA256192f-Robust-10                     614           1972290 ns/op
BenchmarkSphincsPlus/Sign_SHA256192f-Robust-10                        22          50416826 ns/op
BenchmarkSphincsPlus/Verify_SHA256192f-Robust-10                     405           2945441 ns/op
BenchmarkSphincsPlus/Keygen_SHA256192s-Robust-10                       9         125425403 ns/op
BenchmarkSphincsPlus/Sign_SHA256192s-Robust-10                         1        1129996625 ns/op
BenchmarkSphincsPlus/Verify_SHA256192s-Robust-10                    1148           1032008 ns/op
BenchmarkSphincsPlus/Keygen_SHA256192f-Simple-10                    1144           1024943 ns/op
BenchmarkSphincsPlus/Sign_SHA256192f-Simple-10                        43          27046627 ns/op
BenchmarkSphincsPlus/Verify_SHA256192f-Simple-10                     783           1512614 ns/op
BenchmarkSphincsPlus/Keygen_SHA256192s-Simple-10                      16          65659190 ns/op
BenchmarkSphincsPlus/Sign_SHA256192s-Simple-10                         2         605214500 ns/op
BenchmarkSphincsPlus/Verify_SHA256192s-Simple-10                    2228            521625 ns/op
BenchmarkSphincsPlus/Keygen_SHA256128f-Robust-10                     915           1290258 ns/op
BenchmarkSphincsPlus/Sign_SHA256128f-Robust-10                        37          30112207 ns/op
BenchmarkSphincsPlus/Verify_SHA256128f-Robust-10                     627           1954944 ns/op
BenchmarkSphincsPlus/Keygen_SHA256128s-Robust-10                      13          82475558 ns/op
BenchmarkSphincsPlus/Sign_SHA256128s-Robust-10                         2         622622917 ns/op
BenchmarkSphincsPlus/Verify_SHA256128s-Robust-10                    1743            668048 ns/op
BenchmarkSphincsPlus/Keygen_SHA256128f-Simple-10                    1664            707025 ns/op
BenchmarkSphincsPlus/Sign_SHA256128f-Simple-10                        70          16667452 ns/op
BenchmarkSphincsPlus/Verify_SHA256128f-Simple-10                    1152            995405 ns/op
BenchmarkSphincsPlus/Keygen_SHA256128s-Simple-10                      24          46905984 ns/op
BenchmarkSphincsPlus/Sign_SHA256128s-Simple-10                         3         357208319 ns/op
BenchmarkSphincsPlus/Verify_SHA256128s-Simple-10                    3186            374774 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256256f-Robust-10                    49          23147149 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256256f-Robust-10                       3         465220264 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256256f-Robust-10                    80          13796281 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256256s-Robust-10                     3         373107333 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256256s-Robust-10                       1        4484883583 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256256s-Robust-10                   175           6626179 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256256f-Simple-10                   139           8539243 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256256f-Simple-10                       6         176002910 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256256f-Simple-10                   260           4464704 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256256s-Simple-10                     8         136951557 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256256s-Simple-10                       1        1660962542 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256256s-Simple-10                   520           2246542 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256192f-Robust-10                   138           8587640 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256192f-Robust-10                       5         219128258 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256192f-Robust-10                    92          12631454 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256192s-Robust-10                     2         558115688 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256192s-Robust-10                       1        4872980875 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256192s-Robust-10                   268           4493216 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256192f-Simple-10                   358           3318585 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256192f-Simple-10                      13          86344087 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256192f-Simple-10                   258           4798461 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256192s-Simple-10                     5         212549800 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256192s-Simple-10                       1        1941084833 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256192s-Simple-10                   781           1599071 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256128f-Robust-10                   256           4473674 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256128f-Robust-10                      10         104635358 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256128f-Robust-10                   190           6620084 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256128s-Robust-10                     4         286168625 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256128s-Robust-10                       1        2195506667 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256128s-Robust-10                   522           2379696 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256128f-Simple-10                   526           2250558 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256128f-Simple-10                      21          52713778 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256128f-Simple-10                   390           3159005 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256128s-Simple-10                     7         143808946 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256128s-Simple-10                       1        1093304166 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256128s-Simple-10                  1044           1175229 ns/op
PASS
ok      github.com/kasperdi/SPHINCSPLUS-golang/sphincs  187.025s
```

Benchmark after:
```
goos: darwin
goarch: arm64
pkg: github.com/kasperdi/SPHINCSPLUS-golang/sphincs
BenchmarkSphincsPlus/Keygen_SHA256256f-Robust-10                     218           5333676 ns/op
BenchmarkSphincsPlus/Sign_SHA256256f-Robust-10                        10         108579108 ns/op
BenchmarkSphincsPlus/Verify_SHA256256f-Robust-10                     380           3251278 ns/op
BenchmarkSphincsPlus/Keygen_SHA256256s-Robust-10                      13          85646740 ns/op
BenchmarkSphincsPlus/Sign_SHA256256s-Robust-10                         1        1033832584 ns/op
BenchmarkSphincsPlus/Verify_SHA256256s-Robust-10                     753           1589506 ns/op
BenchmarkSphincsPlus/Keygen_SHA256256f-Simple-10                     442           2699011 ns/op
BenchmarkSphincsPlus/Sign_SHA256256f-Simple-10                        20          55474631 ns/op
BenchmarkSphincsPlus/Verify_SHA256256f-Simple-10                     782           1553702 ns/op
BenchmarkSphincsPlus/Keygen_SHA256256s-Simple-10                      26          43273623 ns/op
BenchmarkSphincsPlus/Sign_SHA256256s-Simple-10                         2         531894729 ns/op
BenchmarkSphincsPlus/Verify_SHA256256s-Simple-10                    1500            740159 ns/op
BenchmarkSphincsPlus/Keygen_SHA256192f-Robust-10                     628           1892824 ns/op
BenchmarkSphincsPlus/Sign_SHA256192f-Robust-10                        22          49635525 ns/op
BenchmarkSphincsPlus/Verify_SHA256192f-Robust-10                     388           2881636 ns/op
BenchmarkSphincsPlus/Keygen_SHA256192s-Robust-10                       9         121221356 ns/op
BenchmarkSphincsPlus/Sign_SHA256192s-Robust-10                         1        1105293333 ns/op
BenchmarkSphincsPlus/Verify_SHA256192s-Robust-10                    1198           1010417 ns/op
BenchmarkSphincsPlus/Keygen_SHA256192f-Simple-10                    1106           1032762 ns/op
BenchmarkSphincsPlus/Sign_SHA256192f-Simple-10                        42          27044422 ns/op
BenchmarkSphincsPlus/Verify_SHA256192f-Simple-10                     781           1513767 ns/op
BenchmarkSphincsPlus/Keygen_SHA256192s-Simple-10                      16          66598182 ns/op
BenchmarkSphincsPlus/Sign_SHA256192s-Simple-10                         2         602520292 ns/op
BenchmarkSphincsPlus/Verify_SHA256192s-Simple-10                    2272            538563 ns/op
BenchmarkSphincsPlus/Keygen_SHA256128f-Robust-10                     920           1276046 ns/op
BenchmarkSphincsPlus/Sign_SHA256128f-Robust-10                        38          29645205 ns/op
BenchmarkSphincsPlus/Verify_SHA256128f-Robust-10                     646           1928081 ns/op
BenchmarkSphincsPlus/Keygen_SHA256128s-Robust-10                      14          81674866 ns/op
BenchmarkSphincsPlus/Sign_SHA256128s-Robust-10                         2         612683062 ns/op
BenchmarkSphincsPlus/Verify_SHA256128s-Robust-10                    1770            663169 ns/op
BenchmarkSphincsPlus/Keygen_SHA256128f-Simple-10                    1638            707284 ns/op
BenchmarkSphincsPlus/Sign_SHA256128f-Simple-10                        68          16906893 ns/op
BenchmarkSphincsPlus/Verify_SHA256128f-Simple-10                    1118           1042491 ns/op
BenchmarkSphincsPlus/Keygen_SHA256128s-Simple-10                      25          45409007 ns/op
BenchmarkSphincsPlus/Sign_SHA256128s-Simple-10                         3         344170875 ns/op
BenchmarkSphincsPlus/Verify_SHA256128s-Simple-10                    3570            368351 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256256f-Robust-10                    50          23193195 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256256f-Robust-10                       3         454906306 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256256f-Robust-10                    88          13306718 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256256s-Robust-10                     3         362310611 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256256s-Robust-10                       1        4318693500 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256256s-Robust-10                   175           6752587 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256256f-Simple-10                   140           8476578 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256256f-Simple-10                       6         175612889 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256256f-Simple-10                   265           4734482 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256256s-Simple-10                     8         136674250 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256256s-Simple-10                       1        1652656084 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256256s-Simple-10                   534           2239787 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256192f-Robust-10                   136           8583719 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256192f-Robust-10                       5         217428433 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256192f-Robust-10                    92          12759982 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256192s-Robust-10                     2         546227229 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256192s-Robust-10                       1        4830430083 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256192s-Robust-10                   277           4384409 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256192f-Simple-10                   358           3311640 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256192f-Simple-10                      13          86290199 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256192f-Simple-10                   254           4670123 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256192s-Simple-10                     5         212141883 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256192s-Simple-10                       1        1933979667 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256192s-Simple-10                   770           1549443 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256128f-Robust-10                   261           4498078 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256128f-Robust-10                      10         104096638 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256128f-Robust-10                   183           6611620 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256128s-Robust-10                     4         284859990 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256128s-Robust-10                       1        2178908958 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256128s-Robust-10                   506           2260587 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256128f-Simple-10                   525           2248857 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256128f-Simple-10                      21          52730986 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256128f-Simple-10                   374           3196195 ns/op
BenchmarkSphincsPlus/Keygen_SHAKE256128s-Simple-10                     7         144120012 ns/op
BenchmarkSphincsPlus/Sign_SHAKE256128s-Simple-10                       1        1098813625 ns/op
BenchmarkSphincsPlus/Verify_SHAKE256128s-Simple-10                  1143           1141017 ns/op
PASS
ok      github.com/kasperdi/SPHINCSPLUS-golang/sphincs  186.008s
```